### PR TITLE
Optional connection test

### DIFF
--- a/autossh/CHANGELOG.md
+++ b/autossh/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1
+
+- Switched from the invalid test user 'test' to the known '$USERNAME' for the sake of fail2ban: https://github.com/ThomDietrich/home-assistant-addons/pull/18
+- Added the printout of local IPs to help with https://github.com/ThomDietrich/home-assistant-addons/issues/14
+
 ## 1.2.0
 
 - Changed default port forwarding rule to be compatible with HassOS 9.4+ (https://github.com/home-assistant/operating-system/pull/2246)

--- a/autossh/config.yaml
+++ b/autossh/config.yaml
@@ -1,5 +1,5 @@
 name: SSH Tunnel & Forwarding
-version: 1.2.0
+version: 1.2.1
 slug: autossh
 description: >-
   Permanent HA forwarding and domain linking through an SSH tunnel

--- a/autossh/config.yaml
+++ b/autossh/config.yaml
@@ -25,7 +25,6 @@ options:
     - '127.0.0.1:8123:172.30.32.1:8123'
   other_ssh_options: '-v -N'
   force_keygen: false
-  enable_connection_test: true  
 schema:
   hostname: str
   ssh_port: int
@@ -34,4 +33,3 @@ schema:
     - str
   other_ssh_options: str
   force_keygen: bool
-  enable_connection_test: bool

--- a/autossh/config.yaml
+++ b/autossh/config.yaml
@@ -25,6 +25,7 @@ options:
     - '127.0.0.1:8123:172.30.32.1:8123'
   other_ssh_options: '-v -N'
   force_keygen: false
+  enable_connection_test: true  
 schema:
   hostname: str
   ssh_port: int
@@ -33,3 +34,4 @@ schema:
     - str
   other_ssh_options: str
   force_keygen: bool
+  enable_connection_test: bool

--- a/autossh/run.sh
+++ b/autossh/run.sh
@@ -55,7 +55,7 @@ TEST_COMMAND="/usr/bin/ssh "\
 "-o ChallengeResponseAuthentication=no "\
 "-o StrictHostKeyChecking=no "\
 "-p ${SSH_PORT} -t -t "\
-"test@${HOSTNAME} "\
+"${USERNAME}@${HOSTNAME} "\
 "2>&1 || true"
 
 if eval "${TEST_COMMAND}" | grep -q "Permission denied"; then

--- a/autossh/run.sh
+++ b/autossh/run.sh
@@ -12,7 +12,6 @@ REMOTE_FORWARDING=$(jq --raw-output ".remote_forwarding[]" $CONFIG_PATH)
 
 OTHER_SSH_OPTIONS=$(jq --raw-output ".other_ssh_options" $CONFIG_PATH)
 FORCE_GENERATION=$(jq --raw-output ".force_keygen" $CONFIG_PATH)
-ENABLE_CONNECTION_TEST=$(jq --raw-output ".enable_connection_test" $CONFIG_PATH)
 
 #
 
@@ -47,29 +46,24 @@ if [ -z "$HOSTNAME" ]; then
   exit 1
 fi
 
-# Only run test if user wants to
-if [ "$ENABLE_CONNECTION_TEST" != "false" ]; then
-  TEST_COMMAND="/usr/bin/ssh "\
-  "-o BatchMode=yes "\
-  "-o ConnectTimeout=5 "\
-  "-o PubkeyAuthentication=no "\
-  "-o PasswordAuthentication=no "\
-  "-o KbdInteractiveAuthentication=no "\
-  "-o ChallengeResponseAuthentication=no "\
-  "-o StrictHostKeyChecking=no "\
-  "-p ${SSH_PORT} -t -t "\
-  "test@${HOSTNAME} "\
-  "2>&1 || true"
+TEST_COMMAND="/usr/bin/ssh "\
+"-o BatchMode=yes "\
+"-o ConnectTimeout=5 "\
+"-o PubkeyAuthentication=no "\
+"-o PasswordAuthentication=no "\
+"-o KbdInteractiveAuthentication=no "\
+"-o ChallengeResponseAuthentication=no "\
+"-o StrictHostKeyChecking=no "\
+"-p ${SSH_PORT} -t -t "\
+"test@${HOSTNAME} "\
+"2>&1 || true"
 
-  if eval "${TEST_COMMAND}" | grep -q "Permission denied"; then
-    bashio::log.info "Testing SSH connection... SSH service reachable on remote server"
-  else
-    eval "${TEST_COMMAND}"
-    bashio::log.error "SSH service can't be reached on remote server"
-    exit 1
-  fi
-else  
-    bashio::log.info "Test SSH connection disabled by user configuration!"
+if eval "${TEST_COMMAND}" | grep -q "Permission denied"; then
+  bashio::log.info "Testing SSH connection... SSH service reachable on remote server"
+else
+  eval "${TEST_COMMAND}"
+  bashio::log.error "SSH service can't be reached on remote server"
+  exit 1
 fi
 
 echo ""

--- a/autossh/run.sh
+++ b/autossh/run.sh
@@ -12,6 +12,7 @@ REMOTE_FORWARDING=$(jq --raw-output ".remote_forwarding[]" $CONFIG_PATH)
 
 OTHER_SSH_OPTIONS=$(jq --raw-output ".other_ssh_options" $CONFIG_PATH)
 FORCE_GENERATION=$(jq --raw-output ".force_keygen" $CONFIG_PATH)
+ENABLE_CONNECTION_TEST=$(jq --raw-output ".enable_connection_test" $CONFIG_PATH)
 
 #
 
@@ -46,24 +47,29 @@ if [ -z "$HOSTNAME" ]; then
   exit 1
 fi
 
-TEST_COMMAND="/usr/bin/ssh "\
-"-o BatchMode=yes "\
-"-o ConnectTimeout=5 "\
-"-o PubkeyAuthentication=no "\
-"-o PasswordAuthentication=no "\
-"-o KbdInteractiveAuthentication=no "\
-"-o ChallengeResponseAuthentication=no "\
-"-o StrictHostKeyChecking=no "\
-"-p ${SSH_PORT} -t -t "\
-"test@${HOSTNAME} "\
-"2>&1 || true"
+# Only run test if user wants to
+if [ "$ENABLE_CONNECTION_TEST" != "false" ]; then
+  TEST_COMMAND="/usr/bin/ssh "\
+  "-o BatchMode=yes "\
+  "-o ConnectTimeout=5 "\
+  "-o PubkeyAuthentication=no "\
+  "-o PasswordAuthentication=no "\
+  "-o KbdInteractiveAuthentication=no "\
+  "-o ChallengeResponseAuthentication=no "\
+  "-o StrictHostKeyChecking=no "\
+  "-p ${SSH_PORT} -t -t "\
+  "test@${HOSTNAME} "\
+  "2>&1 || true"
 
-if eval "${TEST_COMMAND}" | grep -q "Permission denied"; then
-  bashio::log.info "Testing SSH connection... SSH service reachable on remote server"
-else
-  eval "${TEST_COMMAND}"
-  bashio::log.error "SSH service can't be reached on remote server"
-  exit 1
+  if eval "${TEST_COMMAND}" | grep -q "Permission denied"; then
+    bashio::log.info "Testing SSH connection... SSH service reachable on remote server"
+  else
+    eval "${TEST_COMMAND}"
+    bashio::log.error "SSH service can't be reached on remote server"
+    exit 1
+  fi
+else  
+    bashio::log.info "Test SSH connection disabled by user configuration!"
 fi
 
 echo ""


### PR DESCRIPTION
Hello, 

I use fail2ban in my setup to secure my SSH proxy. Unfortunately, the test connection of the plugin causes fail2ban to block my homeassistant server. For me, an optional connection test would be completely sufficient. Therefore, I have written a patch that gives the user a configuration option to disable the test. The test is enabled by default. If the user deactivates the connection test, they will be notified in the log.

Looking forward for feedback.

Thanks :)