### PR TITLE
add remote restriction like discussed in #26

### DIFF
--- a/autossh/DOCS.md
+++ b/autossh/DOCS.md
@@ -40,6 +40,8 @@ The add-on creates an SSH keypair and uses it to connect to the given host.
 The public key can be found in the log after the first startup and **must** be copied to the destination server for this add-on to work.
 On your typical Linux system the public key is added to `~/.ssh/authorized_keys`.
 
+Please note that for additional security we prepend some restrictions to the public key that [disallow anything](https://manpages.debian.org/experimental/openssh-server/authorized_keys.5.en.html#restrict) other than port forwarding to the port and host that is specified in the config. For this to work, you **must** leave the `-N` in the `other_ssh_options` section of the default config. If you don't want to use these additional security measures, you can just remove everything before the `ssh-ed25519 …` part of the key printout. Be aware that anyone with access to your local Home Assistant's file system (and thus the private key) will be able to log in to your remote server, and can execute any command if the restrictions are not set. For this reason, we also recommend to create a new user that doesn't have access to anything that isn't needed, if you are not using the docker solution (which provides separation by itself). NEVER add the key to the root user's `authorized_keys` file!
+
 ### Remote Server Configuration
 
 The remote server is the machine hosting the SSH Server and the counterpart for your tunnel connection.

--- a/autossh/run.sh
+++ b/autossh/run.sh
@@ -31,6 +31,7 @@ fi
 
 OTHER_SSH_OPTIONS=$(jq --raw-output ".other_ssh_options" $CONFIG_PATH)
 FORCE_GENERATION=$(jq --raw-output ".force_keygen" $CONFIG_PATH)
+AUTHORIZED_KEYS_RESTRICTION="command=\"\",restrict,port-forwarding,permitopen=\"$FORWARD_REMOTE_IP_ADDRESS:$FORWARD_REMOTE_PORT\""
 
 #
 
@@ -54,7 +55,7 @@ if [ ! -d "$KEY_PATH" ]; then
   mkdir -p "$KEY_PATH"
   ssh-keygen -b 4096 -t ed25519 -N "" -C "hassio-setup-via-autossh" -f "${KEY_PATH}/autossh_rsa_key"
   bashio::log.info "The public key is:"
-  cat "${KEY_PATH}/autossh_rsa_key.pub"
+  echo "${AUTHORIZED_KEYS_RESTRICTION} $(cat "${KEY_PATH}/autossh_rsa_key.pub")"
   bashio::log.warning "Add this key to '~/.ssh/authorized_keys' on your remote server now!"
   bashio::log.warning "Please restart add-on when done. Exiting..."
   exit 1
@@ -64,7 +65,7 @@ fi
 
 echo ""
 bashio::log.info "The public key used by this add-on is:"
-cat "${KEY_PATH}/autossh_rsa_key.pub"
+echo "${AUTHORIZED_KEYS_RESTRICTION} $(cat "${KEY_PATH}/autossh_rsa_key.pub")"
 bashio::log.info "If not done so already, please add the key to '~/.ssh/authorized_keys' on your remote server"
 
 #


### PR DESCRIPTION
Like discussed in issue #26, it would be good to restrict the generated SSH key as much as possible to prevent unwanted usage.

This PR implements this, now the string 

`'command="",restrict,port-forwarding,permitopen="<HOST>:<PORT>"'`

will be prepended to the actual SSH key, which restricts the key's usage to only opening the specified port and disallow running commands, X11 forwarding etc. For further reference, please see: https://manpages.debian.org/experimental/openssh-server/authorized_keys.5.en.html#restrict