### PR TITLE
Add option to skip remote host checks

### DIFF
--- a/autossh/CHANGELOG.md
+++ b/autossh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+
+- Add an option to skip remote host checks
+
 ## 1.3.4
 
 - Improve main loop to ensure continued connection

--- a/autossh/DOCS.md
+++ b/autossh/DOCS.md
@@ -163,3 +163,7 @@ This is optional and for testing purposes a verbose output enabled by `-v` can b
 
 A key pair is generated when the container is first initialized in your environment.
 Set this to `true` if you even need to urge to regenerate a key.
+
+### Option: `skip_remote_host_checks`
+
+Set this to `true` to disable remote host checks. This option is useful for SSH servers that rate-limit incoming connections.

--- a/autossh/config.yaml
+++ b/autossh/config.yaml
@@ -1,5 +1,5 @@
 name: SSH Tunnel & Forwarding
-version: 1.3.4
+version: 1.4.0
 slug: autossh
 description: >-
   Permanent HA forwarding and domain linking through an SSH tunnel
@@ -25,6 +25,7 @@ options:
   remote_port: 8123
   other_ssh_options: '-v -N'
   force_keygen: false
+  skip_remote_host_checks: false
 schema:
   hostname: str
   ssh_port: int
@@ -37,3 +38,4 @@ schema:
     - str
   other_ssh_options: str
   force_keygen: bool
+  skip_remote_host_checks: bool

--- a/autossh/run.sh
+++ b/autossh/run.sh
@@ -31,6 +31,7 @@ fi
 
 OTHER_SSH_OPTIONS=$(jq --raw-output ".other_ssh_options" $CONFIG_PATH)
 FORCE_GENERATION=$(jq --raw-output ".force_keygen" $CONFIG_PATH)
+SKIP_REMOTE_HOST_CHECKS=$(jq --raw-output ".skip_remote_host_checks" $CONFIG_PATH)
 
 #
 
@@ -101,19 +102,24 @@ TEST_COMMAND="/usr/bin/ssh "\
 "${USERNAME}@${HOSTNAME} "\
 "2>&1 || true"
 
-echo ""
-if eval "${TEST_COMMAND}" | grep -q "Permission denied"; then
-  bashio::log.info "Testing SSH service on '${HOSTNAME}:${SSH_PORT}'... SSH service reachable on remote server"
-else
-  eval "${TEST_COMMAND}"
-  bashio::log.error "Testing SSH service on '${HOSTNAME}:${SSH_PORT}'... Failed to reach the SSH service on the remote server. "\
-    "Please check your config and consult the addon documentation."
-  exit 1
-fi
+if [ "$SKIP_REMOTE_HOST_CHECKS" != "true" ]; then
+  echo ""
+  if eval "${TEST_COMMAND}" | grep -q "Permission denied"; then
+    bashio::log.info "Testing SSH service on '${HOSTNAME}:${SSH_PORT}'... SSH service reachable on remote server"
+  else
+    eval "${TEST_COMMAND}"
+    bashio::log.error "Testing SSH service on '${HOSTNAME}:${SSH_PORT}'... Failed to reach the SSH service on the remote server. "\
+      "Please check your config and consult the addon documentation."
+    exit 1
+  fi
 
-echo ""
-bashio::log.info "Remote server host keys:"
-ssh-keyscan -p $SSH_PORT $HOSTNAME || true
+  echo ""
+  bashio::log.info "Remote server host keys:"
+  ssh-keyscan -p $SSH_PORT $HOSTNAME || true
+else
+  echo ""
+  bashio::log.info "Skipped Remote host checks"
+fi
 
 COMMAND="/usr/bin/autossh "\
 "-M 0 "\


### PR DESCRIPTION
This option is useful for SSH servers that rate-limit incoming connections.
